### PR TITLE
fixed the missing -r in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ update key status remotely.
 
 ## Getting started
 
-Clone that repo, `pip install --user requirements.txt`; and you
+Clone that repo, `pip install --user -r requirements.txt`; and you
 might have to do some setup specific to the Stream Deck library
 (FIXME add link to that).
 


### PR DESCRIPTION
The install instructions should read:
```
pip install --user -r requirements.txt
```
The instructions are missing the `-r`
```
pip install --user requirements.txt
```
